### PR TITLE
Better DQ/Pen submission for judges

### DIFF
--- a/app/Http/Controllers/DigitalJudge/DJDQController.php
+++ b/app/Http/Controllers/DigitalJudge/DJDQController.php
@@ -15,6 +15,7 @@ use App\Models\PenaltyCode;
 use App\Models\SERC;
 use App\Models\SERCDisqualification;
 use App\Models\SERCPenalty;
+use App\Models\SpeedEvent;
 use App\Models\SpeedResult;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
@@ -382,5 +383,26 @@ class DJDQController extends Controller
         } else {
             SERCDisqualification::where('team', $teamId)->where('serc', $eventID)->where('code', $code)->delete();
         }
+    }
+
+    public function getEventRelatedCodes(string $eventName)
+    {
+
+        $event = null;
+
+        if (str_starts_with($eventName, 'sp')) {
+
+            $event = CompetitionSpeedEvent::find(substr($eventName, 3));
+
+            $event = $event->getBaseEvent();
+        } else {
+            $event = new SpeedEvent();
+            $event->name = 'SERC';
+        }
+
+
+
+
+        return response()->json(['related' => $event->getEventCodes(), 'other' => $event->getMissingEventCodes()]);
     }
 }

--- a/app/Http/Controllers/DigitalJudge/DJDQController.php
+++ b/app/Http/Controllers/DigitalJudge/DJDQController.php
@@ -140,7 +140,7 @@ class DJDQController extends Controller
     ######################### JUDGE DQ REQUESTS #########################
     public function issue()
     {
-        return view('digitaljudge.dq.judge-issue', ['comp' => DigitalJudge::getClientCompetition()]);
+        return view('digitaljudge.dq.judge-issue', ['comp' => DigitalJudge::getClientCompetition(), 'judge_name' => DigitalJudge::getClientName()]);
     }
 
     public function resolveCode(string $code)

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -290,4 +290,21 @@ class Competition extends Model
 
         return $this->getBrand?->getUsers->where('pivot.role', 'serc')->where('competition', $this->id)->first();
     }
+
+    public function getEventsInDQFormat()
+    {
+
+
+        $events = [];
+
+        $this->getSpeedEvents()->each(function ($event) use (&$events) {
+            $events['sp:' . $event->id] = $event->getName();
+        });
+
+        $this->getSERCs()->each(function ($event) use (&$events) {
+            $events['se:' . $event->id] = $event->name;
+        });
+
+        return $events;
+    }
 }

--- a/app/Models/CompetitionSpeedEvent.php
+++ b/app/Models/CompetitionSpeedEvent.php
@@ -34,7 +34,7 @@ class CompetitionSpeedEvent extends IEvent implements IPenalisable
         return $this->getCompetition->getCompetitionTeams();
     }
 
-    
+
 
     public function getSimpleResults()
     {
@@ -46,7 +46,7 @@ class CompetitionSpeedEvent extends IEvent implements IPenalisable
         return $this->hasOne(SpeedEvent::class, 'id', 'event')->first()->has_penalties;
     }
 
- 
+
     public function getType(): string
     {
         return 'speed';
@@ -79,5 +79,10 @@ class CompetitionSpeedEvent extends IEvent implements IPenalisable
         $result = SpeedResult::where('event', $this->id)->where('competition_team', $teamId)->first();
         $result->disqualification = $code;
         $result->save();
+    }
+
+    public function getBaseEvent()
+    {
+        return $this->hasOne(SpeedEvent::class, 'id', 'event')->first();
     }
 }

--- a/app/Models/EventCode.php
+++ b/app/Models/EventCode.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EventCode extends Model
+{
+    use HasFactory;
+
+
+
+    public function pendq()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/SpeedEvent.php
+++ b/app/Models/SpeedEvent.php
@@ -44,9 +44,17 @@ class SpeedEvent extends Model
             $pen->type = $codes->where('pendq_id', $pen->id)->first()->type;
         }
 
+        $dqCodesFinal = $dqCodes->groupBy('type')->sortBy(function ($group, $type) {
+            return $type === 'GENERIC' ? 1 : 0;
+        });
+        $penCodesFinal = $penCodes->groupBy('type')->sortBy(function ($group, $type) {
+            return $type === 'GENERIC' ? 1 : 0;
+        });
+
+
         return [
-            'dq' => $dqCodes->groupBy('type'),
-            'pen' => $penCodes->groupBy('type')
+            'dq' => $dqCodesFinal,
+            'pen' => $penCodesFinal
         ];
     }
 

--- a/app/Models/SpeedEvent.php
+++ b/app/Models/SpeedEvent.php
@@ -14,4 +14,63 @@ class SpeedEvent extends Model
     {
         return $this->name;
     }
+
+    public function getEventCodes($type = null, $codeType = null)
+    {
+
+        $ec = new EventCode();
+
+        if (!is_null($type)) {
+            $ec = $ec->where('type', $type);
+        }
+
+        if (!is_null($codeType)) {
+            $ec = $ec->where('pendq_type', $codeType);
+        }
+
+        $codes = $ec->where('event', $this->name)->get();
+
+        $dqCodes = $codes->where('pendq_type', 'App\Models\DQCode')->pluck('pendq_id');
+        $penCodes = $codes->where('pendq_type', 'App\Models\PenaltyCode')->pluck('pendq_id');
+
+        $dqCodes = DQCode::whereIn('id', $dqCodes)->get();
+        $penCodes = PenaltyCode::whereIn('id', $penCodes)->get();
+
+        foreach ($dqCodes as $dq) {
+            $dq->type = $codes->where('pendq_id', $dq->id)->first()->type;
+        }
+
+        foreach ($penCodes as $pen) {
+            $pen->type = $codes->where('pendq_id', $pen->id)->first()->type;
+        }
+
+        return [
+            'dq' => $dqCodes->groupBy('type'),
+            'pen' => $penCodes->groupBy('type')
+        ];
+    }
+
+    public function getMissingEventCodes()
+    {
+
+
+        $dqCodes = EventCode::where('event', $this->name)->where('pendq_type', 'App\Models\DQCode')->pluck('pendq_id');
+        $penCodes = EventCode::where('event', $this->name)->where('pendq_type', 'App\Models\PenaltyCode')->pluck('pendq_id');
+
+        $missingDQCodes = DQCode::whereNotIn('id', $dqCodes)->get();
+        $missingPenCodes = PenaltyCode::whereNotIn('id', $penCodes)->get();
+
+        foreach ($missingDQCodes as $dq) {
+            $dq->type = "OTHER";
+        }
+
+        foreach ($missingPenCodes as $pen) {
+            $pen->type = "OTHER";
+        }
+
+        return [
+            'dq' => $missingDQCodes->makeHidden(['created_at', 'updated_at'])->groupBy('type'),
+            'pen' => $missingPenCodes->makeHidden(['created_at', 'updated_at'])->groupBy('type')
+        ];
+    }
 }

--- a/database/migrations/2025_03_08_130735_add_event_codes_table.php
+++ b/database/migrations/2025_03_08_130735_add_event_codes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_codes', function (Blueprint $table) {
+            $table->id();
+            $table->string('event');
+            $table->morphs('pendq');
+            $table->enum('type', ['GENERIC', 'LANE', 'TURN', 'CHANGEOVER', 'CROSSLINE', 'BACKLINE', 'OOF', 'STARTER', 'PICKUP'])->default('GENERIC');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_codes');
+    }
+};

--- a/database/seeders/DQPenLinkSeeder.php
+++ b/database/seeders/DQPenLinkSeeder.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\DQCode;
+use App\Models\EventCode;
+use App\Models\PenaltyCode;
+use App\Models\SpeedEvent;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class DQPenLinkSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $events = [
+            'Swim & Tow' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 14 => 'TURN', 14 => 'PICKUP', 15, 17, 40, 41, 50, 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 206, 501, 502 => 'TURN', 503 => 'PICKUP'],
+                'pen' => [900, 901, 902 => 'LANE', 903 => 'PICKUP', 904 => 'PICKUP', 905 => 'PICKUP', 906, 907 => 'LANE', 908 => 'LANE', 909 => 'LANE', 910 => 'LANE', 911 => 'LANE', 912 => 'LANE', 913 => 'LANE', 914 => 'LANE', 915 => 'PICKUP']
+            ],
+            'Rope Throw' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 15, 17, 40, 41, 50, 53 => 'OOF', 58 => 'STARTER', 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 206, 401 => 'CROSSLINE', 402, 403 => 'CROSSLINE', 403 => 'OOF'],
+                'pen' => [801 => 'CROSSLINE', 802 => 'CROSSLINE', 803 => 'LANE', 804 => 'LANE', 805 => 'LANE', 806 => 'LANE', 807 => 'LANE', 808 => 'BACKLINE', 809 => 'CROSSLINE', 810, 811 => 'CROSSLINE'],
+            ],
+            'Medley' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 14 => 'TURN', 14 => 'PICKUP', 15, 17, 40, 41 => 'CHANGEOVER', 45, 46 => 'LANE', 47 => 'LANE', 48 => 'LANE', 49 => 'LANE', 50, 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 206, 601 => 'TURN'],
+                'pen' => [902 => 'LANE'],
+            ],
+            'Obstacle' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 11 => 'LANE', 12 => 'LANE', 13 => 'LANE', 14 => 'TURN', 15, 17, 40, 41 => 'CHANGEOVER', 50, 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 208],
+            ],
+            'Pool Lifesaver' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 15, 17, 19 => 'LANE', 20 => 'LANE', 39, 40, 41 => 'CHANGEOVER', 42 => 'CHANGEOVER', 43 => 'CHANGEOVER', 50, 59 => 'CHANGEOVER', 60 => 'LANE', 61 => 'LANE', 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 206, 602],
+            ],
+            'Manikin' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 8, 9 => 'OOF', 10 => 'STARTER', 14, 15, 17, 19 => 'LANE', 20 => 'LANE', 21 => 'LANE', 39, 40, 41 => 'CHANGEOVER', 42 => 'CHANGEOVER', 43 => 'CHANGEOVER', 50, 101, 102, 103, 104, 105, 106, 201, 202, 203, 205, 206],
+                'pen' => [902 => 'LANE'],
+            ],
+            'SERC' => [
+                'dq' => [1, 2, 3, 4, 5, 6, 7, 101, 102, 103, 104, 105, 106, 301, 302, 303, 304, 305, 306],
+                'pen' => [701, 702],
+            ]
+        ];
+
+        foreach ($events as $eventName => $values) {
+
+
+            foreach ($values['dq'] as $dq => $type) {
+
+
+                if (!is_string($type)) {
+                    $dq = $type;
+                    $type = null;
+                }
+
+
+                $dqCode = DQCode::find($dq);
+
+                if (!$dqCode) {
+                    continue;
+                }
+
+                $ec = EventCode::firstOrCreate([
+                    'event' => $eventName,
+                    'pendq_id' => $dqCode->id,
+                    'pendq_type' => DQCode::class,
+                ]);
+
+                if ($type) {
+                    $ec->type = $type;
+                }
+
+
+
+                $ec->save();
+            }
+
+            if (array_key_exists('pen', $values)) {
+                foreach ($values['pen'] as $pen => $type) {
+
+                    if (!is_string($type)) {
+                        $pen = $type;
+                        $type = null;
+                    }
+
+                    $penCode = PenaltyCode::find($pen);
+
+                    if (!$penCode) {
+                        continue;
+                    }
+
+                    $ec = EventCode::firstOrCreate([
+                        'event' => $eventName,
+                        'pendq_id' => $penCode->id,
+                        'pendq_type' => PenaltyCode::class,
+                    ]);
+
+                    if ($type) {
+                        $ec->type = $type;
+                    }
+
+                    $ec->save();
+                }
+            }
+        }
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3394,7 +3394,7 @@ div.form-input.checkbox > input {
   padding-bottom: 1.25rem;
 }
 
-a.link, p.link {
+a.link, p.link, span.link {
   cursor: pointer;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -3403,7 +3403,7 @@ a.link, p.link {
   color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
-a.link:hover, p.link:hover {
+a.link:hover, p.link:hover, span.link:hover {
   text-decoration-line: underline;
 }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1607,6 +1607,9 @@ video {
 .h-\[90vh\] {
   height: 90vh;
 }
+.h-auto {
+  height: auto;
+}
 .h-full {
   height: 100%;
 }
@@ -1626,14 +1629,14 @@ video {
 .max-h-\[20px\] {
   max-height: 20px;
 }
+.max-h-\[70vh\] {
+  max-height: 70vh;
+}
 .max-h-\[85vh\] {
   max-height: 85vh;
 }
 .max-h-\[90vh\] {
   max-height: 90vh;
-}
-.max-h-\[70vh\] {
-  max-height: 70vh;
 }
 .min-h-\[20px\] {
   min-height: 20px;
@@ -2353,10 +2356,6 @@ video {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-.bg-red-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
 .bg-opacity-40 {
   --tw-bg-opacity: 0.4;
@@ -3952,6 +3951,10 @@ aside.open {
   margin: 0;
 }
 
+.last\:mb-0:last-child {
+  margin-bottom: 0px;
+}
+
 .first-of-type\:ml-1:first-of-type {
   margin-left: 0.25rem;
 }
@@ -4756,16 +4759,16 @@ aside.open {
     max-width: 50%;
   }
 
+  .xl\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .xl\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .xl\:grid-cols-6 {
     grid-template-columns: repeat(6, minmax(0, 1fr));
-  }
-
-  .xl\:grid-cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -4777,14 +4780,6 @@ aside.open {
 
   .\32xl\:max-w-\[40\%\] {
     max-width: 40%;
-  }
-
-  .\32xl\:grid-cols-5 {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
-  .\32xl\:grid-cols-4 {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .\32xl\:grid-rows-6 {
@@ -4802,12 +4797,12 @@ aside.open {
     grid-column: span 2 / span 2;
   }
 
-  .\33xl\:grid-cols-5 {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
   .\33xl\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .\33xl\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 
@@ -4823,14 +4818,6 @@ aside.open {
 
   .\34xl\:grid-cols-9 {
     grid-template-columns: repeat(9, minmax(0, 1fr));
-  }
-
-  .\34xl\:grid-cols-4 {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .\34xl\:grid-cols-5 {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 

--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -324,7 +324,7 @@ h5 {
   }
  }
 
- a.link, p.link {
+ a.link, p.link, span.link {
   @apply text-blue-700 text-base font-semibold hover:underline cursor-pointer
  }
 

--- a/resources/views/digitaljudge/dq/judge-issue.blade.php
+++ b/resources/views/digitaljudge/dq/judge-issue.blade.php
@@ -434,7 +434,7 @@
             
                 loadCodes() {
                     this.loadingCodes = true;
-                    fetch('{{ route('dj.dq.event-codes', 'X') }}'.replace('X', this.event))
+                    fetch('{{ route('dj.dq.event-codes', 'X') }}'.replace('X', this.submission.event))
                         .then(response => response.json())
                         .then(data => {
                             this.codes = data;
@@ -697,7 +697,7 @@
                     <div x-collapse x-show="dqOpen">
                         <template x-for="(dqs, groupName) in codes?.related?.dq">
                             <div class="mb-5 last:mb-0" x-show="shouldDisplayGroup('dq', dqs)">
-                                <h5 x-text="groupName"></h5>
+                                <h5 x-text="groupName.toLowerCase()" class=" capitalize"></h5>
 
                                 <div class="flex flex-col space-y-2">
                                     <template x-for="dq in dqs">
@@ -715,7 +715,7 @@
 
                         <template x-for="(dqs, groupName) in codes?.other?.dq">
                             <div class="mb-5 last:mb-0" x-show="shouldDisplayGroup('dq', dqs)">
-                                <h5 x-text="groupName"></h5>
+                                <h5 x-text="groupName.toLowerCase()" class=" capitalize"></h5>
 
                                 <div class="flex flex-col space-y-2">
                                     <template x-for="dq in dqs">
@@ -749,7 +749,7 @@
                     <div x-collapse x-show="penOpen">
                         <template x-for="(pens, groupName) in codes?.related?.pen">
                             <div class="mb-5 last:mb-0" x-show="shouldDisplayGroup('p', pens)">
-                                <h5 x-text="groupName"></h5>
+                                <h5 x-text="groupName.toLowerCase()" class=" capitalize"></h5>
 
                                 <div class="flex flex-col space-y-2">
                                     <template x-for="pen in pens">
@@ -768,7 +768,7 @@
 
                         <template x-for="(pens, groupName) in codes?.other?.pen">
                             <div class="mb-5 last:mb-0" x-show="shouldDisplayGroup('p', pens)">
-                                <h5 x-text="groupName"></h5>
+                                <h5 x-text="groupName.toLowerCase()" class=" capitalize"></h5>
 
                                 <div class="flex flex-col space-y-2">
                                     <template x-for="pen in pens">

--- a/resources/views/digitaljudge/dq/judge-issue.blade.php
+++ b/resources/views/digitaljudge/dq/judge-issue.blade.php
@@ -533,7 +533,7 @@
             
                     if (search == '') return true;
             
-                    return code.startsWith(search) || codePad.startsWith(search) || description.toLowerCase().includes(search);
+                    return code.includes(search) || codePad.includes(search) || description.toLowerCase().includes(search);
             
             
                 },

--- a/resources/views/digitaljudge/dq/judge-issue.blade.php
+++ b/resources/views/digitaljudge/dq/judge-issue.blade.php
@@ -206,6 +206,13 @@
                 
                                         d.seconder = { name: d.seconder_name, position: d.seconder_position };
                 
+                                        if (d.turn == null) {
+                                            d.turn = '';
+                                        }
+                                        if (d.length == null) {
+                                            d.length = '';
+                                        }
+                
                                         this.submission = d;
                 
                                         this.$refs.form.querySelectorAll('input, select, textarea ').forEach((el) => {
@@ -513,7 +520,7 @@
                     if (this.presetEvent != '') {
                         this.submission.event = this.presetEvent;
                         this.activeStep = 2;
-                        return;
+            
                     } else {
                         this.activeStep = 1;
                     }
@@ -605,8 +612,6 @@
                 let url = new URLSearchParams(window.location.search);
                 if (url.has('event')) {
                     presetEvent = url.get('event');
-            
-            
                 }
             
             

--- a/routes/digitaljudge.php
+++ b/routes/digitaljudge.php
@@ -83,6 +83,8 @@ Route::domain(RouteHelpers::domainRemap("judge."))->group(function () {
         Route::post('submission', [DJDQController::class, 'submission'])->name('dj.dq.submission');
         Route::get('submission/{submission}/info', [DJDQController::class, 'getSubmission'])->name('dj.dq.submission.info');
         Route::get('submission/{submission}/status', [DJDQController::class, 'submissionStatus'])->name('dj.dq.submission.status');
+
+        Route::get('event-codes/{event}', [DJDQController::class, 'getEventRelatedCodes'])->name('dj.dq.event-codes');
     });
 
     Route::middleware('isHeadJudge')->group(function () {


### PR DESCRIPTION
Adds a much faster way for judges to select an event, team and DQ/Pen code for teams. 

1. Select an event
2. Select a team
3. Search for a DQ/Pen code, with descriptions listed in a big list, then click it
4. Add final details - Name auto filled
5. Submit

Rest of the process follows the current behaviour judges expect.