### PR TITLE
Mark-splits update

### DIFF
--- a/app/Http/Controllers/SERCController.php
+++ b/app/Http/Controllers/SERCController.php
@@ -391,17 +391,37 @@ class SERCController extends Controller
 
         $results = SERCResult::with('entity')->whereIn('marking_point', $marking_points->pluck('id'))->get();
 
-        // group by the entity and then order by marking point id
-        $grouped = $results->groupBy(function ($item) use ($comp) {
-            return $item->entity ? $item->entity->getName($comp) : 'Unknown';
-        })->map(function ($item) {
-            return $item->sortBy('marking_point')->map(function ($mp) {
-                return [
+        // create ordered marking point IDs array
+        $mp_ids = $marking_points->pluck('id')->values()->toArray();
 
-                    'result' => $mp->result,
-                    'date_recorded' => $mp->created_at->toDateTimeString(),
-                ];
+        // Get all entities from the draw
+        $allEntities = $serc->getDraw->map(function ($draw) use ($comp) {
+            return $draw->entity->getName($comp);
+        })->unique();
+
+        // group by the entity
+        $resultsByEntity = $results->groupBy(function ($item) use ($comp) {
+            return $item->entity ? $item->entity->getName($comp) : 'Unknown';
+        });
+
+        // Build results for ALL entities (including those with no results)
+        $grouped = $allEntities->mapWithKeys(function ($entityName) use ($resultsByEntity, $mp_ids) {
+            $entityResults = $resultsByEntity->get($entityName, collect());
+            $resultMap = $entityResults->keyBy('marking_point');
+            
+            // Build array aligned with marking points, filling gaps with null
+            $alignedResults = collect($mp_ids)->map(function ($mp_id) use ($resultMap) {
+                if (isset($resultMap[$mp_id])) {
+                    return [
+                        
+                        'result' => $resultMap[$mp_id]->result,
+                        'date_recorded' => $resultMap[$mp_id]->created_at->toDateTimeString(),
+                    ];
+                }
+                return null;
             })->values();
+
+            return [$entityName => $alignedResults];
         });
 
         $marking_point_names = $marking_points->sortBy('id')->map(function ($mp) {

--- a/app/Models/SERCMarkingPoint.php
+++ b/app/Models/SERCMarkingPoint.php
@@ -33,6 +33,16 @@ class SERCMarkingPoint extends Model
         //});
     }
 
+    
+    public function getLastUpdatedForTeam(Entity $entity)
+    {
+
+        $mpId = $this->id;
+
+        return SERCResult::where('marking_point', $mpId)->forEntity($entity)->first()?->updated_at ?: null;
+    }
+
+
     public function getJudge()
     {
         return $this->belongsTo(SERCJudge::class, 'judge', 'id');

--- a/resources/views/competition/events/sercs/edit-team-results.blade.php
+++ b/resources/views/competition/events/sercs/edit-team-results.blade.php
@@ -39,6 +39,10 @@
                                 </th>
 
                                 <th scope="col">
+                                    Last Updated
+                                </th>
+
+                                <th scope="col">
                                     Value
                                 </th>
 
@@ -57,6 +61,9 @@
                                 <th scope="row">
                                     <span class="pl-4">Disqualification</span>
                                 </th>
+                                <td class="text-sm text-gray-600">
+                                    {{ $serc->getEntityDisqualifications($team)->first()?->updated_at?->format('Y-m-d H:i:s') ?? '' }}
+                                </td>
                                 <td class="table-input">
                                     <input class="table-input" table-cell table-cell-name="disqualification"
                                         placeholder="DQ###" x-data x-mask="DQ999" type="text"
@@ -67,6 +74,9 @@
                                 <th scope="row">
                                     <span class="pl-4">Penalties</span>
                                 </th>
+                                <td class="text-sm text-gray-600">
+                                    {{ $serc->getEntityPenalties($team)->first()?->updated_at?->format('Y-m-d H:i:s') ?? '' }}
+                                </td>
                                 <td class="table-input">
                                     <input class="table-input" table-cell table-cell-name="penalties" placeholder="P###"
                                         type="text"
@@ -88,6 +98,10 @@
                                             <span class="pl-4">{{ $mp->name }}</span>
                                         </th>
 
+                                        <td class="text-sm text-gray-600">
+                                            {{ $mp->getLastUpdatedForTeam($team)?->format('Y-m-d H:i:s') ?? '' }}
+                                        </td>
+
                                         <td class="table-input">
 
                                             <input class="table-input" table-cell table-cell-name="score" min="0"
@@ -96,9 +110,9 @@
 
                                         </td>
 
+                                        
 
-
-
+                                        
                                     </tr>
                                 @endforeach
 

--- a/resources/views/competition/events/sercs/mark-splits.blade.php
+++ b/resources/views/competition/events/sercs/mark-splits.blade.php
@@ -56,7 +56,7 @@
                             <tr>
                                 <th x-text="entry_name"></th>
                                 <template x-for="mp in entry_data">
-                                    <td x-text="mp.result"></td>
+                                    <td x-text="mp?.result ?? '-'"></td>
                                 </template>
                             </tr>
                     </tbody>


### PR DESCRIPTION
### Commit 1:
- controller: fill results array with all teams using null values for gaps and ensuring each objective has a mark so results display properly in table (i.e. not left to right when results length < mp's length)
- view: handle null values with '-'

### Commit 2:
add 'last updated at' timestamps to edit results view
- adding function to SERCMARKINGPOINT model
```php
    public function getLastUpdatedForTeam(Entity $entity)
    {
        $mpId = $this->id;
        return SERCResult::where('marking_point', $mpId)->forEntity($entity)->first()?->updated_at ?: null;
    }
```
- accomadating changes in the view blade file